### PR TITLE
Add order count pie charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "dependencies": {
     "antd": "3.10.1",
+    "crossfilter2": "1.4.6",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.6.0",
+    "fast-deep-equal": "2.0.1",
     "http-status": "1.2.0",
     "node-sass": "4.9.4",
     "prop-types": "15.6.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "enzyme-adapter-react-16": "1.6.0",
     "fast-deep-equal": "2.0.1",
     "http-status": "1.2.0",
+    "moment": "2.22.2",
     "node-sass": "4.9.4",
     "prop-types": "15.6.2",
     "react": "^16.5.2",

--- a/src/App/Layout/AppLayout.jsx
+++ b/src/App/Layout/AppLayout.jsx
@@ -24,7 +24,7 @@ class AppLayout extends Component {
 
     return (
       <Layout>
-        {process.env.REACT_APP_SIDE_MENU ? (
+        {Boolean(process.env.REACT_APP_SIDE_MENU) ? (
             <AppSidebar collapsed={this.state.collapsed} onCollapse={this.onCollapse}/>
           ) :
           ''

--- a/src/App/__tests__/__snapshots__/AppLayout.test.js.snap
+++ b/src/App/__tests__/__snapshots__/AppLayout.test.js.snap
@@ -18,10 +18,7 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "children": Array [
-        <AppSidebar
-          collapsed={false}
-          onCollapse={[Function]}
-        />,
+        "",
         <Adapter>
           
           <AppContent />
@@ -30,19 +27,7 @@ ShallowWrapper {
     },
     "ref": null,
     "rendered": Array [
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": Array [],
-          "collapsed": false,
-          "onCollapse": [Function],
-        },
-        "ref": null,
-        "rendered": Array [],
-        "type": [Function],
-      },
+      "",
       Object {
         "instance": null,
         "key": undefined,
@@ -80,10 +65,7 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "children": Array [
-          <AppSidebar
-            collapsed={false}
-            onCollapse={[Function]}
-          />,
+          "",
           <Adapter>
             
             <AppContent />
@@ -92,19 +74,7 @@ ShallowWrapper {
       },
       "ref": null,
       "rendered": Array [
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": Array [],
-            "collapsed": false,
-            "onCollapse": [Function],
-          },
-          "ref": null,
-          "rendered": Array [],
-          "type": [Function],
-        },
+        "",
         Object {
           "instance": null,
           "key": undefined,

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -7,10 +7,11 @@ import { VictoryPie } from 'victory';
  * Abstract Pie Chart wrapper
  * @param data
  */
-const PieChart = ({ data }) => {
+const PieChart = ({ data, ...rest }) => {
   return (
     <VictoryPie
       data={data}
+      {...rest}
     />
   );
 };

--- a/src/components/crossfilter/crossfilter.js
+++ b/src/components/crossfilter/crossfilter.js
@@ -1,0 +1,3 @@
+const crossfilter = require('crossfilter2');
+
+export default crossfilter;

--- a/src/views/CrossVisualizer/CrossVisualizer.jsx
+++ b/src/views/CrossVisualizer/CrossVisualizer.jsx
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'speedux';
-import {
-  Spin,
-} from 'antd';
+import { Spin, } from 'antd';
+
+import module from './CrossVisualizer.module';
+import OrdersCountPie from './OrdersCountPie/OrdersCountPie';
 
 import './CrossVisualizer.scss';
-import module from './CrossVisualizer.module';
-import PieChart from '../../components/PieChart/PieChart';
 
 
 class CrossVisualizer extends Component {
@@ -49,12 +48,58 @@ class CrossVisualizer extends Component {
 
     return (
       <div>
-        {loading ? (
-            <Spin/>
-          )
+        {loading ? (<Spin/>)
           : (
-            <PieChart
-            />
+            <React.Fragment>
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+              <OrdersCountPie
+                orders={[]}
+                payments={[]}
+              />
+            </React.Fragment>
           )}
       </div>
     );

--- a/src/views/CrossVisualizer/CrossVisualizer.jsx
+++ b/src/views/CrossVisualizer/CrossVisualizer.jsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'speedux';
-import { Spin, } from 'antd';
+import { Spin } from 'antd';
+import crossfilter from '../../components/crossfilter/crossfilter';
 
 import module from './CrossVisualizer.module';
 import OrdersCountPie from './OrdersCountPie/OrdersCountPie';
@@ -11,92 +12,66 @@ import './CrossVisualizer.scss';
 
 class CrossVisualizer extends Component {
   static propTypes = {
-    actions: PropTypes.shape({}),
+    actions: PropTypes.shape({
+      getOrdersData: PropTypes.func
+    }).isRequired,
     state: PropTypes.shape({
       loading: PropTypes.bool,
       error: PropTypes.bool,
       errorMsg: PropTypes.string,
-    })
-  };
-
-  static defaultProps = {
-    actions: {},
-    state: {
-      columns: [],
-      allColumns: [],
-      campaignsCount: 0,
-      current: 1,
-    },
-    history: {},
-    location: {},
+      ordersData: PropTypes.arrayOf(PropTypes.shape({
+        userid: PropTypes.string,
+        orderid: PropTypes.number,
+        orderAmount: PropTypes.string,
+        orderdate: PropTypes.string,
+        paymentMethod: PropTypes.string,
+        branch: PropTypes.string,
+        deliveryArea: PropTypes.string,
+      }))
+    }).isRequired
   };
 
   state = {};
 
   componentDidMount() {
-
+    const { actions } = this.props;
+    actions.getOrdersData();
   }
 
   componentDidUpdate(prevProps) {
-
   }
+
+  prepareOrdersCountData = (ordersData) => {
+    // Serialize data using crossfilter to be:
+    // {key: paymentMethod, value: count}
+    const crossedOrdersData = crossfilter(ordersData);
+    const dimension = crossedOrdersData.dimension(record => record.paymentMethod);
+    const categories = dimension.group().reduceCount();
+
+    const data = categories.all();
+    return {
+      categories,
+      dimension,
+      data
+    };
+
+  };
 
   render() {
 
     const { state } = this.props;
-    const { loading } = state;
+    const { loading, ordersData } = state;
+
+    const ordersCountData = (ordersData && ordersData.length) ? this.prepareOrdersCountData(ordersData) : null;
 
     return (
       <div>
         {loading ? (<Spin/>)
           : (
             <React.Fragment>
+              <h3>Orders by <br /><strong>payment method</strong></h3>
               <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
-                payments={[]}
-              />
-              <OrdersCountPie
-                orders={[]}
+                orders={ordersCountData ? ordersCountData.data : []}
                 payments={[]}
               />
             </React.Fragment>

--- a/src/views/CrossVisualizer/CrossVisualizer.jsx
+++ b/src/views/CrossVisualizer/CrossVisualizer.jsx
@@ -41,28 +41,22 @@ class CrossVisualizer extends Component {
   componentDidUpdate(prevProps) {
   }
 
-  prepareOrdersCountData = (ordersData) => {
-    // Serialize data using crossfilter to be:
-    // {key: paymentMethod, value: count}
-    const crossedOrdersData = crossfilter(ordersData);
-    const dimension = crossedOrdersData.dimension(record => record.paymentMethod);
-    const categories = dimension.group().reduceCount();
+  normalizeData = (ordersData) => {
+    const currencyParser = (value) => value && parseFloat(value.replace(/[$,]+/g, ''));
 
-    const data = categories.all();
-    return {
-      categories,
-      dimension,
-      data
-    };
-
+    // Normalize data for Crossfilter usage!
+    ordersData.forEach(order => {
+      order.orderAmount = currencyParser(order.orderAmount);
+    });
+    return ordersData;
   };
 
-  render() {
+    render() {
 
     const { state } = this.props;
     const { loading, ordersData } = state;
 
-    const ordersCountData = (ordersData && ordersData.length) ? this.prepareOrdersCountData(ordersData) : null;
+    const orders = (ordersData && ordersData.length) ? crossfilter(this.normalizeData(ordersData)) : null;
 
     return (
       <div>
@@ -71,8 +65,7 @@ class CrossVisualizer extends Component {
             <React.Fragment>
               <h3>Orders by <br /><strong>payment method</strong></h3>
               <OrdersCountPie
-                orders={ordersCountData ? ordersCountData.data : []}
-                payments={[]}
+                orders={orders}
               />
             </React.Fragment>
           )}

--- a/src/views/CrossVisualizer/CrossVisualizer.module.js
+++ b/src/views/CrossVisualizer/CrossVisualizer.module.js
@@ -7,7 +7,7 @@ export default createModule('CrossVisualizer', {
     loading: false,
     error: false,
     errorMsg: '',
-    chartsData: {},
+    ordersData: [],
   },
 
   actions: {
@@ -19,23 +19,19 @@ export default createModule('CrossVisualizer', {
         loading: true,
       };
 
-      const allData = yield OrdersAPI.getOrders().catch(e => e);
+      const ordersData = yield OrdersAPI.getOrders().catch(e => e);
 
-      if (allData instanceof Error) {
-        const { errorMsg } = JSON.parse(allData.message);
+      if (ordersData instanceof Error) {
+        const { errorMsg } = JSON.parse(ordersData.message);
         yield {
           loading: false,
           error: true,
           errorMsg,
         };
-      }
-
-      const chartsData = allData.data;
-
-      if (chartsData) {
+      } else {
         yield {
           loading: false,
-          chartsData,
+          ordersData,
         };
       }
     },

--- a/src/views/CrossVisualizer/OrdersCountPie/OrdersByPayment.jsx
+++ b/src/views/CrossVisualizer/OrdersCountPie/OrdersByPayment.jsx
@@ -1,26 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { VictoryPie } from 'victory';
+import PieChart from '../../../components/PieChart/PieChart';
 
 /**
  * Abstract Pie Chart wrapper
  * @param data
  */
-const PieChart = ({ data }) => {
+const OrdersByPayment = ({ data }) => {
   return (
-    <VictoryPie
+    <PieChart
       data={data}
     />
   );
 };
 
-PieChart.propTypes = {
+OrdersByPayment.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({}))
 };
 
-PieChart.defaultProps = {
+OrdersByPayment.defaultProps = {
   data: [],
 };
 
-export default PieChart;
+export default OrdersByPayment;

--- a/src/views/CrossVisualizer/OrdersCountPie/OrdersByPayment.jsx
+++ b/src/views/CrossVisualizer/OrdersCountPie/OrdersByPayment.jsx
@@ -7,10 +7,11 @@ import PieChart from '../../../components/PieChart/PieChart';
  * Abstract Pie Chart wrapper
  * @param data
  */
-const OrdersByPayment = ({ data }) => {
+const OrdersByPayment = ({ data, ...rest }) => {
   return (
     <PieChart
       data={data}
+      {...rest}
     />
   );
 };

--- a/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
+++ b/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Row, Col } from 'antd';
+import OrdersByPayment from './OrdersByPayment';
+
+const mockData = [
+  { x: 'Cats', y: 35 },
+  { x: 'Dogs', y: 40 },
+  { x: 'Birds', y: 55 }
+];
+
+class OrdersCountPie extends Component {
+  static propTypes = {
+    orders: PropTypes.arrayOf(PropTypes.shape({})),
+    payments: PropTypes.arrayOf(PropTypes.shape({})),
+  };
+
+  static defaultProps = {
+    orders: [],
+    payments: [],
+  };
+
+  render() {
+    return (
+      <div>
+        <Row type="flex" justify="space-around">
+          <Col span={4}>
+            <OrdersByPayment data={mockData} />
+          </Col>
+          <Col span={4}>
+            <OrdersByPayment data={mockData} />
+          </Col>
+          <Col span={4}>
+            <OrdersByPayment data={mockData} />
+          </Col>
+        </Row>
+      </div>
+    );
+  }
+}
+
+export default OrdersCountPie;

--- a/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
+++ b/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
@@ -3,12 +3,9 @@ import PropTypes from 'prop-types';
 import { Row, Col } from 'antd';
 import OrdersByPayment from './OrdersByPayment';
 
-const mockData = [
-  { x: 'Cats', y: 35 },
-  { x: 'Dogs', y: 40 },
-  { x: 'Birds', y: 55 }
-];
-
+/**
+ *
+ */
 class OrdersCountPie extends Component {
   static propTypes = {
     orders: PropTypes.arrayOf(PropTypes.shape({})),
@@ -21,17 +18,31 @@ class OrdersCountPie extends Component {
   };
 
   render() {
+    const { orders } = this.props;
+
     return (
       <div>
         <Row type="flex" justify="space-around">
           <Col span={4}>
-            <OrdersByPayment data={mockData} />
+            <OrdersByPayment
+              data={orders}
+              x="key"
+              y="value"
+            />
           </Col>
           <Col span={4}>
-            <OrdersByPayment data={mockData} />
+            <OrdersByPayment
+              data={orders}
+              x="key"
+              y="value"
+            />
           </Col>
           <Col span={4}>
-            <OrdersByPayment data={mockData} />
+            <OrdersByPayment
+              data={orders}
+              x="key"
+              y="value"
+            />
           </Col>
         </Row>
       </div>

--- a/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
+++ b/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { utc } from 'moment';
 import { Col, Row } from 'antd';
 import PieChart from '../../../components/PieChart/PieChart';
 
@@ -30,8 +31,13 @@ class OrdersCountPie extends Component {
 
     // utils
     const filterAmountRange = (amount, min, max) => amount && amount > min && amount <= max;
+    const filterDayTimeRange = (date, min, max) => {
+      const hour = utc(date).hours();
+      return hour > min && hour <= max;
+    };
 
     // Orders by orderAmount
+    // Less than $10, $10-$20, $20-40, $40-$70, $70 or more
     const ordersByAmountDimension = crossedOrdersData.dimension(record => {
       const amount = record.orderAmount;
 
@@ -45,15 +51,39 @@ class OrdersCountPie extends Component {
         case filterAmountRange(amount, 70, Infinity):
           return '$70 or more';
         case filterAmountRange(amount, -Infinity, 10):
-        default:
           return 'Less than $10';
+        default:
+          return 'N/A';
       }
     });
     const ordersByAmountData = ordersByAmountDimension.group().reduceCount().all();
 
+    // Orders by Order time
+    // Morning 6am-12pm, Afternoon 12-5pm, Evening 5-8pm, Night 8pm-6am
+    const ordersByTimeDimension = crossedOrdersData.dimension(record => {
+      const date = record.orderdate;
+
+      switch (true) {
+        case filterDayTimeRange(date, 6, 12):
+          return 'Morning';
+        case filterDayTimeRange(date, 12, 17):
+          return 'Afternoon';
+        case filterDayTimeRange(date, 17, 20):
+          return 'Evening';
+        case filterDayTimeRange(date, 0, 6):
+        case filterDayTimeRange(date, 20, 23):
+          return 'Night';
+        // TODO: issue with some date filters!
+        default:
+          return 'N/A';
+      }
+    });
+    const ordersByTimeData = ordersByTimeDimension.group().reduceCount().all();
+
     return {
       ordersByPaymentMethodData,
       ordersByAmountData,
+      ordersByTimeData,
     };
 
   };
@@ -79,13 +109,13 @@ class OrdersCountPie extends Component {
               y="value"
             />
           </Col>
-          {/*<Col span={4}>
+          <Col span={4}>
             <PieChart
-              data={orders}
+              data={ordersCrossed && ordersCrossed.ordersByTimeData}
               x="key"
               y="value"
             />
-          </Col>*/}
+          </Col>
         </Row>
       </div>
     );

--- a/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
+++ b/src/views/CrossVisualizer/OrdersCountPie/OrdersCountPie.jsx
@@ -1,49 +1,91 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'antd';
-import OrdersByPayment from './OrdersByPayment';
+import { Col, Row } from 'antd';
+import PieChart from '../../../components/PieChart/PieChart';
 
 /**
  *
  */
 class OrdersCountPie extends Component {
   static propTypes = {
-    orders: PropTypes.arrayOf(PropTypes.shape({})),
-    payments: PropTypes.arrayOf(PropTypes.shape({})),
+    orders: PropTypes.shape({}),
   };
 
   static defaultProps = {
-    orders: [],
-    payments: [],
+    orders: {},
+  };
+
+  /**
+   * Receive a crossfilter object and process it
+   * @param crossedOrdersData
+   * @return {{ordersByPaymentMethodData: Array<crossfilter.Grouping<crossfilter.NaturallyOrderedValue, crossfilter.NaturallyOrderedValue>>, orderBySizeData: Array<crossfilter.Grouping<crossfilter.NaturallyOrderedValue, crossfilter.NaturallyOrderedValue>>}}
+   */
+  prepareOrdersCountData = (crossedOrdersData) => {
+    // Serialize and group data using crossfilter to be
+    // for-example: {key: 'paymentMethod', value: 20}
+
+    // Orders by paymentMethod
+    const ordersByPaymentMethodDimension = crossedOrdersData.dimension(record => record.paymentMethod);
+    const ordersByPaymentMethodData = ordersByPaymentMethodDimension.group().reduceCount().all();
+
+    // utils
+    const filterAmountRange = (amount, min, max) => amount && amount > min && amount <= max;
+
+    // Orders by orderAmount
+    const ordersByAmountDimension = crossedOrdersData.dimension(record => {
+      const amount = record.orderAmount;
+
+      switch (true) {
+        case filterAmountRange(amount, 10, 20):
+          return '$10-$20';
+        case filterAmountRange(amount, 20, 40):
+          return '$20-$40';
+        case filterAmountRange(amount, 40, 70):
+          return '$40-$70';
+        case filterAmountRange(amount, 70, Infinity):
+          return '$70 or more';
+        case filterAmountRange(amount, -Infinity, 10):
+        default:
+          return 'Less than $10';
+      }
+    });
+    const ordersByAmountData = ordersByAmountDimension.group().reduceCount().all();
+
+    return {
+      ordersByPaymentMethodData,
+      ordersByAmountData,
+    };
+
   };
 
   render() {
     const { orders } = this.props;
+    const ordersCrossed = orders ? this.prepareOrdersCountData(orders) : null;
 
     return (
       <div>
         <Row type="flex" justify="space-around">
           <Col span={4}>
-            <OrdersByPayment
-              data={orders}
+            <PieChart
+              data={ordersCrossed && ordersCrossed.ordersByPaymentMethodData}
               x="key"
               y="value"
             />
           </Col>
           <Col span={4}>
-            <OrdersByPayment
-              data={orders}
+            <PieChart
+              data={ordersCrossed && ordersCrossed.ordersByAmountData}
               x="key"
               y="value"
             />
           </Col>
-          <Col span={4}>
-            <OrdersByPayment
+          {/*<Col span={4}>
+            <PieChart
               data={orders}
               x="key"
               y="value"
             />
-          </Col>
+          </Col>*/}
         </Row>
       </div>
     );

--- a/src/views/CrossVisualizer/OrdersCountPie/__tests__/OrdersByPayment.test.js
+++ b/src/views/CrossVisualizer/OrdersCountPie/__tests__/OrdersByPayment.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme/build';
+import OrdersByPayment from '../OrdersByPayment';
+
+describe('<OrdersByPayment /> component', () => {
+  it('should render with simple data', () => {
+    const mockData = [
+      { x: 'Cats', y: 35 },
+      { x: 'Dogs', y: 40 },
+      { x: 'Birds', y: 55 }
+    ];
+
+    const rendered = shallow(
+      <OrdersByPayment
+        data={mockData}
+      />
+    );
+
+    expect(rendered).toMatchSnapshot();
+  });
+});
+

--- a/src/views/CrossVisualizer/OrdersCountPie/__tests__/__snapshots__/OrdersByPayment.test.js.snap
+++ b/src/views/CrossVisualizer/OrdersCountPie/__tests__/__snapshots__/OrdersByPayment.test.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<OrdersByPayment /> component should render with simple data 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <OrdersByPayment
+    data={
+      Array [
+        Object {
+          "x": "Cats",
+          "y": 35,
+        },
+        Object {
+          "x": "Dogs",
+          "y": 40,
+        },
+        Object {
+          "x": "Birds",
+          "y": 55,
+        },
+      ]
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "function",
+    "props": Object {
+      "data": Array [
+        Object {
+          "x": "Cats",
+          "y": 35,
+        },
+        Object {
+          "x": "Dogs",
+          "y": 40,
+        },
+        Object {
+          "x": "Birds",
+          "y": 55,
+        },
+      ],
+    },
+    "ref": null,
+    "rendered": null,
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "data": Array [
+          Object {
+            "x": "Cats",
+            "y": 35,
+          },
+          Object {
+            "x": "Dogs",
+            "y": 40,
+          },
+          Object {
+            "x": "Birds",
+            "y": 55,
+          },
+        ],
+      },
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/views/CrossVisualizer/__tests__/__snapshots__/CrossVisualizer.test.js.snap
+++ b/src/views/CrossVisualizer/__tests__/__snapshots__/CrossVisualizer.test.js.snap
@@ -39,14 +39,7 @@ ShallowWrapper {
       "chartsData": Object {
         "id": "001",
       },
-      "history": Object {},
-      "location": Object {},
-      "state": Object {
-        "allColumns": Array [],
-        "campaignsCount": 0,
-        "columns": Array [],
-        "current": 1,
-      },
+      "state": undefined,
       "store": Object {
         "clearActions": [Function],
         "dispatch": [Function],
@@ -91,14 +84,7 @@ ShallowWrapper {
         "chartsData": Object {
           "id": "001",
         },
-        "history": Object {},
-        "location": Object {},
-        "state": Object {
-          "allColumns": Array [],
-          "campaignsCount": 0,
-          "columns": Array [],
-          "current": 1,
-        },
+        "state": undefined,
         "store": Object {
           "clearActions": [Function],
           "dispatch": [Function],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5885,7 +5885,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
-moment@2.x, moment@^2.22.2:
+moment@2.22.2, moment@2.x, moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,6 +2386,12 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+crossfilter2@1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/crossfilter2/-/crossfilter2-1.4.6.tgz#c173f0d75a04344ad226b1f8ae747f0386f98750"
+  dependencies:
+    lodash.result "^4.4.0"
+
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -3521,13 +3527,13 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
+fast-deep-equal@2.0.1, fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
-
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -5524,6 +5530,10 @@ lodash.memoize@^4.1.2:
 lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+
+lodash.result@^4.4.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.result/-/lodash.result-4.5.2.tgz#cb45b27fb914eaa8d8ee6f0ce7b2870b87cb70aa"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Add orders count pie charts
- [ ] Add Initial App Layout
- [ ] Add Initial Orders Count Pie Charts layout
- [ ] Add CrossFilter and create dimensions/groups for:
	- [ ] Orders by payment method
	- [ ] Orders by order time
	- [ ] Orders by order size
- [ ] Add Pie Charts
